### PR TITLE
Fixed Issue #6

### DIFF
--- a/scalation_kernel/kernel.py
+++ b/scalation_kernel/kernel.py
@@ -163,6 +163,13 @@ class ScalaTionKernel(Kernel):
         parser.add_argument('z')
         parser.add_argument('--title')
 
+        
+        
+        parser.add_argument('//')
+        parser.add_argument('/*')
+        
+        
+        
         args    = parser.parse_args(shlex.split(plot_args))
         figfile = BytesIO()
 
@@ -213,6 +220,12 @@ class ScalaTionKernel(Kernel):
         parser.add_argument('--ylabel')
         parser.add_argument('--axis')
 
+        
+        parser.add_argument('--//')
+        parser.add_argument('--/*')
+        
+        
+        
         args    = parser.parse_args(shlex.split(plot_args))
         figfile = BytesIO()
 


### PR DESCRIPTION
Issue #6. Added additional arguments to the parse function to take in trailing comments such as `//` or `/* */` so the notebook wouldn't crash when a user tries to comment their code.